### PR TITLE
Mensaje bienvenida REVISAR LIB

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -139,12 +139,12 @@ function init(bot_user) {
 
   /// Only welcome people to the main group,
   /// and only (of course) if the added user isn't the bot
-  bot.on('new_chat_participant', function (msg) {
-    if ( msg.new_chat_participant.id === bot_user.id )
+  bot.on('new_chat_member', function (msg) {
+    if ( msg.new_chat_member.id === bot_user.id )
       return;
 
     if ( msg.chat.id === GROUPS.main_group_id )
-      this.sendMessage(msg.chat.id, utils.render(WELCOME_MESSAGE, { name: msg.new_chat_participant.first_name }))
+      this.sendMessage(msg.chat.id, utils.render(WELCOME_MESSAGE, { name: msg.new_chat_member.first_name }))
           .catch(utils.DEFAULT_PROMISE_ERROR_HANDLER);
   });
 


### PR DESCRIPTION
la nueva API cambia new_chat_participant por new_chat_member.
Hay que revisar que la libreria que uses del bot de telegram también haya hecho el cambio para la linea 142 bot.on

> Renamed the fields new_chat_participant and left_chat_participant of the Message object to new_chat_member and left_chat_member.
